### PR TITLE
chore!: drop support for node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
-        node-version: [10, 12, 14, 16]
+        node-version: [12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Pino v7 (and in turn pino-http v6) dropped support for node 10.
To be able to adopt pino-http v6 in https://github.com/pinojs/koa-pino-logger/pull/36, this repo also needs to drop it.

Would constitute as a major change. 